### PR TITLE
:bug: Fix bulk import missing required inBudget field

### DIFF
--- a/web/app/components/import/ImportWizard.vue
+++ b/web/app/components/import/ImportWizard.vue
@@ -324,6 +324,7 @@ async function handleTestDb() {
             categoryId: tx.categoryId ?? undefined,
             merchantId: tx.merchantId ?? undefined,
             isRebalance: tx.isRebalance,
+            inBudget: true,
         }));
 
         const result = await transactionStore.testBulkTransactions(selectedAccountId.value, payload);
@@ -379,6 +380,7 @@ async function handleImport() {
                 categoryId: tx.categoryId ?? undefined,
                 merchantId: tx.merchantId ?? undefined,
                 isRebalance: tx.isRebalance,
+                inBudget: true,
             }));
 
         const result = await transactionStore.createBulkTransactions(selectedAccountId.value, payload);


### PR DESCRIPTION
## Problem

Importing transactions via `POST /transaction/account/:id/bulk` failed with a 400 error:

```json
{
  "message": ["inBudget must be a boolean value", "inBudget should not be empty"],
  "error": "Bad Request",
  "statusCode": 400
}
```

## Cause

The bulk endpoint validates each item against `CreateTransactionDto`, where `inBudget` is required (`@IsNotEmpty() @IsBoolean()`). The import wizard built its payload without ever setting `inBudget`, so the server rejected the request. The `CreateTransactionPayload` type already declares `inBudget` as required, so this was also a type mismatch that wasn't surfacing.

## Fix

Set `inBudget: true` in both payload builders in `ImportWizard.vue` — the test/dry-run path (`handleTestDb`) and the actual import path (`handleImport`). Imported transactions now default to counting toward the budget, matching the default for new transactions.