### PR TITLE
🐛 Fixes related to recurring transactions & minor changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowy-monorepo",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "license": "CC-BY-NC-SA-4.0",
     "author": "Tom CZEKAJ aka Xen0Xys",
     "workspaces": [

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowy-server",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "scripts": {
         "build": "bun build.ts",
         "start": "bun --bun nest start",

--- a/server/src/modules/accounting/recurring-transaction/models/dto/update-recurring-transaction.dto.ts
+++ b/server/src/modules/accounting/recurring-transaction/models/dto/update-recurring-transaction.dto.ts
@@ -15,6 +15,10 @@ import {RecurrenceFrequency} from "../../../../../../prisma/generated/client";
 
 export class UpdateRecurringTransactionDto {
     @IsOptional()
+    @IsUUID("7")
+    accountId?: string;
+
+    @IsOptional()
     @IsString()
     @Length(1, 255)
     name?: string;

--- a/server/src/modules/accounting/recurring-transaction/recurring-transaction.service.ts
+++ b/server/src/modules/accounting/recurring-transaction/recurring-transaction.service.ts
@@ -100,6 +100,9 @@ export class RecurringTransactionService {
             await this.validateReferencesOwnership(user, dto.merchantId ?? undefined, dto.categoryId ?? undefined);
         }
         if (dto.timezone !== undefined) this.validateTimezone(dto.timezone);
+        if (dto.accountId !== undefined && dto.accountId !== rt.account_id) {
+            await this.getOwnedAccountOrThrow(user, dto.accountId);
+        }
 
         const merged = {
             frequency: dto.frequency ?? rt.frequency,
@@ -123,6 +126,7 @@ export class RecurringTransactionService {
             dto.timezone !== undefined;
 
         const data: Prisma.RecurringTransactionsUncheckedUpdateInput = {};
+        if (dto.accountId !== undefined && dto.accountId !== rt.account_id) data.account_id = dto.accountId;
         if (dto.name !== undefined) data.name = dto.name;
         if (dto.amount !== undefined) data.amount = this.toDecimal(dto.amount);
         if (dto.merchantId !== undefined) data.merchant_id = dto.merchantId;

--- a/server/src/modules/accounting/recurring-transaction/recurring-transaction.service.ts
+++ b/server/src/modules/accounting/recurring-transaction/recurring-transaction.service.ts
@@ -100,8 +100,10 @@ export class RecurringTransactionService {
             await this.validateReferencesOwnership(user, dto.merchantId ?? undefined, dto.categoryId ?? undefined);
         }
         if (dto.timezone !== undefined) this.validateTimezone(dto.timezone);
-        if (dto.accountId !== undefined && dto.accountId !== rt.account_id) {
-            await this.getOwnedAccountOrThrow(user, dto.accountId);
+
+        const accountChanged = dto.accountId !== undefined && dto.accountId !== rt.account_id;
+        if (accountChanged) {
+            await this.getOwnedAccountOrThrow(user, dto.accountId!);
         }
 
         const merged = {
@@ -126,7 +128,7 @@ export class RecurringTransactionService {
             dto.timezone !== undefined;
 
         const data: Prisma.RecurringTransactionsUncheckedUpdateInput = {};
-        if (dto.accountId !== undefined && dto.accountId !== rt.account_id) data.account_id = dto.accountId;
+        if (accountChanged) data.account_id = dto.accountId;
         if (dto.name !== undefined) data.name = dto.name;
         if (dto.amount !== undefined) data.amount = this.toDecimal(dto.amount);
         if (dto.merchantId !== undefined) data.merchant_id = dto.merchantId;

--- a/web/app/components/recurring/RecurringTransactionDetailDialog.vue
+++ b/web/app/components/recurring/RecurringTransactionDetailDialog.vue
@@ -306,23 +306,23 @@ function goToTransaction(transactionId: string) {
                 </TabsContent>
             </Tabs>
         </DialogContent>
-
-        <AlertDialog :open="isDeleteOpen" @update:open="(v) => (isDeleteOpen = v)">
-            <AlertDialogContent>
-                <AlertDialogHeader>
-                    <AlertDialogTitle>{{ t("common.areYouSure") }}</AlertDialogTitle>
-                    <AlertDialogDescription>{{ t("recurring.detail.deleteDescription") }}</AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                    <AlertDialogCancel>{{ t("common.cancel") }}</AlertDialogCancel>
-                    <AlertDialogAction
-                        class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                        :disabled="isDeleting"
-                        @click="handleDelete">
-                        {{ isDeleting ? t("common.deleting") : t("common.delete") }}
-                    </AlertDialogAction>
-                </AlertDialogFooter>
-            </AlertDialogContent>
-        </AlertDialog>
     </Dialog>
+
+    <AlertDialog :open="isDeleteOpen" @update:open="(v) => (isDeleteOpen = v)">
+        <AlertDialogContent>
+            <AlertDialogHeader>
+                <AlertDialogTitle>{{ t("common.areYouSure") }}</AlertDialogTitle>
+                <AlertDialogDescription>{{ t("recurring.detail.deleteDescription") }}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+                <AlertDialogCancel>{{ t("common.cancel") }}</AlertDialogCancel>
+                <AlertDialogAction
+                    class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    :disabled="isDeleting"
+                    @click="handleDelete">
+                    {{ isDeleting ? t("common.deleting") : t("common.delete") }}
+                </AlertDialogAction>
+            </AlertDialogFooter>
+        </AlertDialogContent>
+    </AlertDialog>
 </template>

--- a/web/app/components/recurring/RecurringTransactionFormDialog.vue
+++ b/web/app/components/recurring/RecurringTransactionFormDialog.vue
@@ -155,7 +155,7 @@ const initForm = () => {
         formData.value = {
             name: "",
             amount: 0,
-            accountId: availableAccounts.value[0]?.id ?? "",
+            accountId: "",
             categoryId: "none",
             merchantId: "none",
             frequency: "MONTHLY",
@@ -169,10 +169,21 @@ const initForm = () => {
     }
 };
 
+const loadData = async () => {
+    try {
+        await Promise.all([referenceStore.fetchReferences(), accountStore.fetchAccounts()]);
+    } catch {
+        toast.error(t("recurring.form.errors.loadData"));
+    }
+};
+
 watch(
     () => props.open,
     (open) => {
-        if (open) initForm();
+        if (open) {
+            loadData();
+            initForm();
+        }
     },
     {immediate: true},
 );

--- a/web/app/components/recurring/RecurringTransactionFormDialog.vue
+++ b/web/app/components/recurring/RecurringTransactionFormDialog.vue
@@ -277,6 +277,7 @@ const submit = async () => {
         if (isEditing.value && props.recurringTransaction) {
             const updatePayload: UpdateRecurringTransactionPayload = {
                 ...basePayload,
+                accountId: formData.value.accountId,
                 merchantId: formData.value.merchantId === "none" ? null : formData.value.merchantId,
                 categoryId: formData.value.categoryId === "none" ? null : formData.value.categoryId,
             };
@@ -365,7 +366,7 @@ const close = () => emit("update:open", false);
 
                         <div class="grid gap-2">
                             <Label for="recurring-account">{{ t("recurring.form.account") }}</Label>
-                            <Select v-model="formData.accountId" :disabled="isEditing">
+                            <Select v-model="formData.accountId">
                                 <SelectTrigger id="recurring-account">
                                     <SelectValue :placeholder="t('recurring.form.accountPlaceholder')" />
                                 </SelectTrigger>
@@ -375,6 +376,9 @@ const close = () => emit("update:open", false);
                                     </SelectItem>
                                 </SelectContent>
                             </Select>
+                            <p v-if="isEditing" class="text-muted-foreground text-xs">
+                                {{ t("recurring.form.accountChangeHint") }}
+                            </p>
                         </div>
 
                         <div class="grid gap-4 sm:grid-cols-2">

--- a/web/app/components/recurring/RecurringTransactionFormDialog.vue
+++ b/web/app/components/recurring/RecurringTransactionFormDialog.vue
@@ -14,6 +14,7 @@ import {
 import {useAccountStore} from "~/stores/account.store";
 import {useReferenceStore} from "~/stores/reference.store";
 import {useFamilyStore} from "~/stores/family.store";
+import {useDescriptionReferenceAutoFill} from "~/composables/useDescriptionReferenceAutoFill";
 import {Button} from "~/components/ui/button";
 import {Input} from "~/components/ui/input";
 import {Label} from "~/components/ui/label";
@@ -112,7 +113,25 @@ const formData = ref({
 
 const isEditing = computed(() => Boolean(props.recurringTransaction));
 
+const {reset: resetAutoFill} = useDescriptionReferenceAutoFill({
+    description: computed({
+        get: () => formData.value.name,
+        set: (value) => (formData.value.name = value),
+    }),
+    categoryId: computed({
+        get: () => formData.value.categoryId,
+        set: (value) => (formData.value.categoryId = value),
+    }),
+    merchantId: computed({
+        get: () => formData.value.merchantId,
+        set: (value) => (formData.value.merchantId = value),
+    }),
+    categories: availableCategories,
+    merchants: availableMerchants,
+});
+
 const initForm = () => {
+    resetAutoFill();
     if (props.recurringTransaction) {
         const rt = props.recurringTransaction;
         transactionType.value = rt.amount < 0 ? "expense" : "income";

--- a/web/app/components/recurring/RecurringTransactionFormDialog.vue
+++ b/web/app/components/recurring/RecurringTransactionFormDialog.vue
@@ -179,10 +179,12 @@ const loadData = async () => {
 
 watch(
     () => props.open,
-    (open) => {
-        if (open) {
-            loadData();
-            initForm();
+    async (open) => {
+        if (!open) return;
+        initForm();
+        await loadData();
+        if (props.recurringTransaction) {
+            formData.value.accountId = props.recurringTransaction.accountId;
         }
     },
     {immediate: true},
@@ -279,10 +281,7 @@ const isValid = computed(() => {
 
 const timezoneOpen = ref(false);
 
-const handleTimezoneSelect = (value: string | number | boolean | Array<string | number | boolean>) => {
-    formData.value.timezone = String(value);
-    timezoneOpen.value = false;
-};
+const handleTimezoneSelect = () => (timezoneOpen.value = false);
 
 const submit = async () => {
     if (!isValid.value) return;

--- a/web/app/components/transactions/TransactionFormModal.vue
+++ b/web/app/components/transactions/TransactionFormModal.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import {computed, ref, watch} from "vue";
-import {watchDebounced, useEventListener} from "@vueuse/core";
+import {useEventListener} from "@vueuse/core";
 import {useI18n} from "vue-i18n";
 import {toast} from "vue-sonner";
 import {
@@ -13,7 +13,7 @@ import {
 import {useReferenceStore} from "~/stores/reference.store";
 import {useAccountStore} from "~/stores/account.store";
 import {useFamilyStore} from "~/stores/family.store";
-import {useReferenceMatcher} from "~/composables/useReferenceMatcher";
+import {useDescriptionReferenceAutoFill} from "~/composables/useDescriptionReferenceAutoFill";
 import {toCurrency} from "~/lib/currency";
 import {cn} from "~/lib/utils";
 import {Button} from "~/components/ui/button";
@@ -78,7 +78,6 @@ const isCreateMerchantDialogOpen = ref(false);
 const isLinkTransferSheetOpen = ref(false);
 const keepLinkedTransaction = ref(false);
 const isUnlinking = ref(false);
-const lastAutoFilledDescription = ref<string | null>(null);
 
 const currency = computed(() => familyStore.family?.currency || "USD");
 const formatCurrency = (value: number) => toCurrency(value, currency.value);
@@ -130,9 +129,27 @@ const isEditing = computed(() => Boolean(props.transaction));
 
 const today = () => new Date().toISOString().split("T")[0] || "";
 
+const {reset: resetAutoFill} = useDescriptionReferenceAutoFill({
+    description: computed({
+        get: () => formData.value.description,
+        set: (value) => (formData.value.description = value),
+    }),
+    categoryId: computed({
+        get: () => formData.value.categoryId,
+        set: (value) => (formData.value.categoryId = value),
+    }),
+    merchantId: computed({
+        get: () => formData.value.merchantId,
+        set: (value) => (formData.value.merchantId = value),
+    }),
+    categories: availableCategories,
+    merchants: availableMerchants,
+    enabled: computed(() => transactionType.value !== "transfer"),
+});
+
 const initFormFromProps = () => {
     keepLinkedTransaction.value = false;
-    lastAutoFilledDescription.value = null;
+    resetAutoFill();
 
     if (props.transaction) {
         transactionType.value = props.transaction.amount < 0 ? "expense" : "income";
@@ -192,49 +209,6 @@ watch(
 watch(() => props.transaction, initFormFromProps, {immediate: true});
 
 const onOpenChange = (open: boolean) => emit("update:open", open);
-
-const {matchDescription, primaryKeywordFor} = useReferenceMatcher();
-
-const canAutoFillDescription = () =>
-    formData.value.description === "" || formData.value.description === lastAutoFilledDescription.value;
-
-const composedAutoDescription = computed(() => {
-    if (transactionType.value === "transfer") return "";
-    const merchant =
-        formData.value.merchantId && formData.value.merchantId !== "none"
-            ? availableMerchants.value.find((m) => m.id === formData.value.merchantId)
-            : null;
-    const category =
-        formData.value.categoryId && formData.value.categoryId !== "none"
-            ? availableCategories.value.find((c) => c.id === formData.value.categoryId)
-            : null;
-    const parts: string[] = [];
-    if (category?.autoCompleteEnabled) parts.push(primaryKeywordFor(category));
-    if (merchant?.autoCompleteEnabled) parts.push(primaryKeywordFor(merchant));
-    return parts.filter((part) => part.length > 0).join(" ");
-});
-
-watchDebounced(
-    () => formData.value.description,
-    (description) => {
-        if (transactionType.value === "transfer") return;
-        if (!description || !description.trim()) return;
-        const match = matchDescription(description, availableCategories.value, availableMerchants.value);
-        if (match.categoryId && formData.value.categoryId === "none") {
-            formData.value.categoryId = match.categoryId;
-        }
-        if (match.merchantId && formData.value.merchantId === "none") {
-            formData.value.merchantId = match.merchantId;
-        }
-    },
-    {debounce: 300},
-);
-
-watch(composedAutoDescription, (auto) => {
-    if (!canAutoFillDescription()) return;
-    formData.value.description = auto;
-    lastAutoFilledDescription.value = auto || null;
-});
 
 const canSubmitStandard = computed(() => {
     if (transactionType.value === "transfer") return false;

--- a/web/app/composables/useDescriptionReferenceAutoFill.ts
+++ b/web/app/composables/useDescriptionReferenceAutoFill.ts
@@ -1,0 +1,70 @@
+import {computed, ref, watch, type ComputedRef, type Ref, type WritableComputedRef} from "vue";
+import {watchDebounced} from "@vueuse/core";
+import type {TransactionCategory, TransactionMerchant} from "~/stores/transaction.store";
+import {useReferenceMatcher} from "~/composables/useReferenceMatcher";
+
+type StringSource = Ref<string> | WritableComputedRef<string>;
+
+type Options = {
+    description: StringSource;
+    categoryId: StringSource;
+    merchantId: StringSource;
+    categories: ComputedRef<TransactionCategory[]>;
+    merchants: ComputedRef<TransactionMerchant[]>;
+    enabled?: ComputedRef<boolean>;
+    debounceMs?: number;
+};
+
+export function useDescriptionReferenceAutoFill(options: Options) {
+    const {matchDescription, primaryKeywordFor} = useReferenceMatcher();
+    const lastAutoFilledDescription = ref<string | null>(null);
+    const isEnabled = () => options.enabled?.value ?? true;
+
+    const canAutoFillDescription = () =>
+        options.description.value === "" || options.description.value === lastAutoFilledDescription.value;
+
+    const composedAutoDescription = computed(() => {
+        if (!isEnabled()) return "";
+        const merchant =
+            options.merchantId.value && options.merchantId.value !== "none"
+                ? options.merchants.value.find((m) => m.id === options.merchantId.value)
+                : null;
+        const category =
+            options.categoryId.value && options.categoryId.value !== "none"
+                ? options.categories.value.find((c) => c.id === options.categoryId.value)
+                : null;
+        const parts: string[] = [];
+        if (category?.autoCompleteEnabled) parts.push(primaryKeywordFor(category));
+        if (merchant?.autoCompleteEnabled) parts.push(primaryKeywordFor(merchant));
+        return parts.filter((part) => part.length > 0).join(" ");
+    });
+
+    watchDebounced(
+        () => options.description.value,
+        (description) => {
+            if (!isEnabled()) return;
+            if (!description || !description.trim()) return;
+            const match = matchDescription(description, options.categories.value, options.merchants.value);
+            if (match.categoryId && options.categoryId.value === "none") {
+                options.categoryId.value = match.categoryId;
+            }
+            if (match.merchantId && options.merchantId.value === "none") {
+                options.merchantId.value = match.merchantId;
+            }
+        },
+        {debounce: options.debounceMs ?? 300},
+    );
+
+    watch(composedAutoDescription, (auto) => {
+        if (!isEnabled()) return;
+        if (!canAutoFillDescription()) return;
+        options.description.value = auto;
+        lastAutoFilledDescription.value = auto || null;
+    });
+
+    const reset = () => {
+        lastAutoFilledDescription.value = null;
+    };
+
+    return {reset};
+}

--- a/web/app/composables/useDescriptionReferenceAutoFill.ts
+++ b/web/app/composables/useDescriptionReferenceAutoFill.ts
@@ -1,6 +1,6 @@
 import {computed, ref, watch, type ComputedRef, type Ref, type WritableComputedRef} from "vue";
 import {watchDebounced} from "@vueuse/core";
-import type {TransactionCategory, TransactionMerchant} from "~/stores/transaction.store";
+import type {TransactionCategory, TransactionMerchant} from "~/stores/reference.store";
 import {useReferenceMatcher} from "~/composables/useReferenceMatcher";
 
 type StringSource = Ref<string> | WritableComputedRef<string>;

--- a/web/app/composables/useReferenceMatcher.ts
+++ b/web/app/composables/useReferenceMatcher.ts
@@ -1,4 +1,4 @@
-import type {TransactionCategory, TransactionMerchant} from "~/stores/transaction.store";
+import type {TransactionCategory, TransactionMerchant} from "~/stores/reference.store";
 
 type Matchable = {
     id: string;

--- a/web/app/stores/recurring-transaction.store.ts
+++ b/web/app/stores/recurring-transaction.store.ts
@@ -64,6 +64,7 @@ export type CreateRecurringTransactionPayload = {
 };
 
 export type UpdateRecurringTransactionPayload = {
+    accountId?: string;
     name?: string;
     amount?: number;
     merchantId?: string | null;

--- a/web/app/stores/reference.store.ts
+++ b/web/app/stores/reference.store.ts
@@ -2,8 +2,31 @@ import {defineStore} from "pinia";
 import {toast} from "vue-sonner";
 import {useApi} from "~/composables/useApi";
 import {useUserStore} from "~/stores/user.store";
-import type {TransactionCategory, TransactionMerchant} from "~/stores/transaction.store";
 import {i18nT} from "~/utils/i18n";
+
+export type TransactionMerchant = {
+    id: string;
+    userId: string;
+    name: string;
+    keywords: string[];
+    primaryKeyword: string | null;
+    autoCompleteEnabled: boolean;
+    createdAt?: string;
+    updatedAt?: string;
+};
+
+export type TransactionCategory = {
+    id: string;
+    userId: string;
+    name: string;
+    hexColor: string;
+    icon: string;
+    keywords: string[];
+    primaryKeyword: string | null;
+    autoCompleteEnabled: boolean;
+    createdAt?: string;
+    updatedAt?: string;
+};
 
 type CreateCategoryPayload = {
     name: string;

--- a/web/app/stores/transaction.store.ts
+++ b/web/app/stores/transaction.store.ts
@@ -3,30 +3,9 @@ import {toast} from "vue-sonner";
 import {useApi} from "~/composables/useApi";
 import {useUserStore} from "~/stores/user.store";
 import {i18nT} from "~/utils/i18n";
+import type {TransactionCategory, TransactionMerchant} from "~/stores/reference.store";
 
-export type TransactionMerchant = {
-    id: string;
-    userId: string;
-    name: string;
-    keywords: string[];
-    primaryKeyword: string | null;
-    autoCompleteEnabled: boolean;
-    createdAt?: string;
-    updatedAt?: string;
-};
-
-export type TransactionCategory = {
-    id: string;
-    userId: string;
-    name: string;
-    hexColor: string;
-    icon: string;
-    keywords: string[];
-    primaryKeyword: string | null;
-    autoCompleteEnabled: boolean;
-    createdAt?: string;
-    updatedAt?: string;
-};
+export type {TransactionCategory, TransactionMerchant};
 
 export type Transaction = {
     id: string;

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -1138,7 +1138,10 @@
             "inBudget": "Include in budget",
             "inBudgetHint": "Count this transaction towards budget forecasts.",
             "enabled": "Enabled",
-            "enabledHint": "When disabled, no transaction will be created but the schedule keeps advancing."
+            "enabledHint": "When disabled, no transaction will be created but the schedule keeps advancing.",
+            "errors": {
+                "loadData": "Failed to load required data"
+            }
         },
         "list": {
             "empty": "No recurring transactions yet",

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -1116,6 +1116,7 @@
             "namePlaceholder": "e.g. Rent, Netflix, Salary",
             "account": "Account",
             "accountPlaceholder": "Select an account",
+            "accountChangeHint": "Changing the account only affects future occurrences. Already generated transactions stay on the original account.",
             "category": "Category",
             "categoryPlaceholder": "Select a category",
             "categoryEmpty": "No category found.",

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -1138,7 +1138,10 @@
             "inBudget": "Inclure dans le budget",
             "inBudgetHint": "Compte cette transaction dans les prévisions du budget.",
             "enabled": "Activée",
-            "enabledHint": "Désactivée, aucune transaction ne sera créée mais la planification avance quand même."
+            "enabledHint": "Désactivée, aucune transaction ne sera créée mais la planification avance quand même.",
+            "errors": {
+                "loadData": "Impossible de charger les données requises"
+            }
         },
         "list": {
             "empty": "Aucune transaction récurrente",

--- a/web/i18n/locales/fr.json
+++ b/web/i18n/locales/fr.json
@@ -1116,6 +1116,7 @@
             "namePlaceholder": "Ex. Loyer, Netflix, Salaire",
             "account": "Compte",
             "accountPlaceholder": "Sélectionner un compte",
+            "accountChangeHint": "Le changement de compte ne s'applique qu'aux prochaines occurrences. Les transactions déjà générées restent sur le compte d'origine.",
             "category": "Catégorie",
             "categoryPlaceholder": "Sélectionner une catégorie",
             "categoryEmpty": "Aucune catégorie trouvée.",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowy-web",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "type": "module",
     "scripts": {
         "build": "nuxt build",


### PR DESCRIPTION
## Summary

Improves editing of recurring transactions and factors out the shared
description ↔ reference auto-fill logic between the transaction modal and
the recurring transaction dialog.

- Allows editing the account of an existing recurring transaction (backend +
  frontend). The change only affects future occurrences; already generated
  transactions stay on the original account (hint displayed in the form).
- Extracts the description ↔ category/merchant auto-fill logic into a new
  `useDescriptionReferenceAutoFill` composable, reused by both
  `TransactionFormModal.vue` and `RecurringTransactionFormDialog.vue`.
- Fixes account selection in the recurring transaction form: no implicit
  pre-selection anymore, the user must now explicitly pick an account.
- Loads references and accounts when the recurring dialog opens, with a
  toast on failure.

## Linked issue

Closes #38 

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] CI or tooling

## Screenshots

<!-- Add before/after captures for the "Recurring transaction" modal
     (editable Account field + hint, description auto-fill from
     category/merchant). -->

## Checklist

- [ ] `bun run lint` passes
- [ ] Tests added or updated when behavior changes
- [ ] `bun test` passes locally
- [x] Prisma schema changes include a migration <!-- N/A: no schema changes -->
- [ ] Documentation updated (README, DEPLOYMENT, CONTRIBUTING) if needed
- [x] No `console.log` left in committed code
- [x] Commit messages follow the gitmoji convention